### PR TITLE
Update README with Spanish project overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,58 @@
-# shopping_list_app
+# Shopping List App
 
-A new Flutter project.
+Aplicación móvil hecha en Flutter para gestionar una lista de compras con categorías, cantidades y sincronización en tiempo real mediante Firebase Realtime Database.
 
-## Getting Started
+## ✨ Características
 
-This project is a starting point for a Flutter application.
+- Listado de productos con nombre, cantidad y categoría.
+- Alta y baja de productos desde la interfaz.
+- Sincronización con Firebase Realtime Database.
+- Tema oscuro personalizado.
 
-A few resources to get you started if this is your first Flutter project:
+## 🧱 Tecnologías
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
+- Flutter
+- Dart
+- Firebase Realtime Database
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+## ✅ Requisitos
+
+- Flutter SDK instalado (https://docs.flutter.dev/get-started/install)
+- Emulador Android/iOS o dispositivo físico
+
+## 🚀 Ejecución local
+
+1. Instala las dependencias:
+
+   ```bash
+   flutter pub get
+   ```
+
+2. Ejecuta la app:
+
+   ```bash
+   flutter run
+   ```
+
+## 🔧 Configuración de Firebase
+
+La app utiliza una instancia de Firebase Realtime Database configurada en el código (`lib/widgets/grocery_list.dart`).
+Si quieres usar tu propia base de datos:
+
+1. Crea un proyecto en Firebase.
+2. Habilita Realtime Database.
+3. Sustituye el host en el `Uri.https(...)` por el de tu proyecto.
+
+## 🗂 Estructura del proyecto
+
+```
+lib/
+  data/          # Datos y constantes (categorías)
+  models/        # Modelos de datos
+  widgets/       # Widgets de UI
+  main.dart      # Punto de entrada
+```
+
+## 📄 Licencia
+
+Este proyecto se proporciona como ejemplo educativo. Puedes adaptarlo libremente.


### PR DESCRIPTION
### Motivation
- Replace the generic Flutter starter README with a concise, project-specific Spanish overview to improve onboarding for contributors and users.
- Call out the app's dependency on Firebase Realtime Database and where to change the database host in the code (`lib/widgets/grocery_list.dart`).

### Description
- Overwrote `README.md` with a Spanish README that includes: Features, Technologies, Requirements, Local Run, Firebase configuration, Project structure, and License.
- Added local setup and run commands (`flutter pub get` and `flutter run`) and instructions to substitute the Realtime Database host in the `Uri.https(...)` call.
- Focused the content on developer onboarding and quick setup for this Flutter shopping list app.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982bd54440c832eabfafb5864ee1a4c)